### PR TITLE
Add support for semver java_version and JDK 11.0.10

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,15 +9,13 @@
 
 - name: precondition - java_subversion
   fail: msg="ERROR - required variable 'java_subversion' missing."
-  when: java_subversion is not defined
+  when: java_version is not regex("\d+\.\d+\.\d+") and java_subversion is not defined
 
 - name: precondition - java_install_jce
   fail: msg="ERROR - required variable 'java_install_jce' missing."
   when: java_install_jce is not defined
 
 - include: set-role-variables.yml
-
-
 
 - name: install libselinux-python binary for Ansible to work
   yum: name=libselinux-python state=present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,7 @@
 - name: check if specific version of Oracle JDK is installed? (Mac OS X)
   block:
     - name: get jdk_info
-      shell: /usr/libexec/java_home -v "{{ jdk_version }}"
+      shell: /usr/libexec/java_home -V 2>&1 | grep -E '\b{{ jdk_version.replace('.', '\.') }}\b'
       register: jdk_info
       changed_when: false
       failed_when: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,19 +21,40 @@
   yum: name=libselinux-python state=present
   when: ansible_pkg_mgr == "yum"
 
-- name: copy scripts to server
-  copy: src="../files/check-java-version.sh"  dest="{{ java_download_path }}/"  mode="a+x"
+# TODO: Support multiple JDK installations.
+- name: check if specific version of Oracle JDK is installed? (non-Mac)
+  block:
+    - name: copy scripts to server
+      copy: src="../files/check-java-version.sh"  dest="{{ java_download_path }}/"  mode="a+x"
 
-- name: check if specific version of Oracle JDK is installed?
-  shell: LC_ALL="en_US.UTF-8"  {{ java_download_path }}/check-java-version.sh  "{{ jdk_version }}"
-  register: jdk_info
-  changed_when: false
-  failed_when: jdk_info.rc > 0
+    - name: get jdk_info
+      shell: LC_ALL="en_US.UTF-8"  {{ java_download_path }}/check-java-version.sh  "{{ jdk_version }}"
+      register: jdk_info
+      changed_when: false
+      failed_when: jdk_info.rc > 0
 
-#- debug: var=jdk_info
+    - name: set jdk_already_installed
+      set_fact:
+        jdk_already_installed: "{{ (jdk_info.stdout|from_json).found | bool }}"
+  when: ansible_os_family != "Darwin"
+
+- name: check if specific version of Oracle JDK is installed? (Mac OS X)
+  block:
+    - name: get jdk_info
+      shell: /usr/libexec/java_home -v "{{ jdk_version }}"
+      register: jdk_info
+      changed_when: false
+      failed_when: false
+
+    - name: set jdk_already_installed
+      set_fact:
+        jdk_already_installed: "{{ (jdk_info.rc == 0) | bool }}"
+  when: ansible_os_family == "Darwin"
+
+#- debug: var=jdk_already_installed
 
 - include: install.yml
-  when: (jdk_info.stdout|from_json).not_found
+  when: not jdk_already_installed
 
 - name: delegate to JCE zip installation process
   include: install_jce.yml

--- a/tasks/set-role-variables-semver.yml
+++ b/tasks/set-role-variables-semver.yml
@@ -1,0 +1,41 @@
+---
+# file: tasks/set-role-variables-semver.yml
+# set necessary role variables for semver.
+#
+
+- name: set java OS for Mac OS X
+  set_fact:
+    jdk_os: osx
+  when: ansible_os_family == 'Darwin'
+
+- name: set jdk_version
+  set_fact:
+    jdk_version: "{{ java_version }}"
+
+
+#
+# version-specific variables
+#
+
+- name: set internal vars for 11.0.10
+  set_fact:
+    jdk_version_detail: 11.0.10%2B8
+    jdk_tarball_hash: 020c4a6d33b74f6a9d2bc6fbf189da81
+  when: java_version == "11.0.10"
+
+- name: compose filename
+  set_fact:
+    jdk_tarball_file: "jdk-{{ java_version }}_{{ jdk_os }}-{{ jdk_arch }}_bin"
+
+
+#
+# directories
+#
+
+- name: set java installation directory on Mac OS X
+  set_fact:
+    # The Java installation directory on Mac OS X is determined by the package itself.
+    java_install_dir: /no_such_directory
+    java_default_link_name: default
+    java_home: "/Library/Java/JavaVirtualMachines/jdk-{{ java_version }}.jdk/Contents/Home"
+  when: ansible_os_family == "Darwin"

--- a/tasks/set-role-variables-version-subversion.yml
+++ b/tasks/set-role-variables-version-subversion.yml
@@ -1,0 +1,154 @@
+---
+# file: tasks/set-role-variables-version-subversion.yml
+# set necessary role variables.
+#
+
+- name: set java OS for Mac OS X
+  set_fact:
+    jdk_os: macosx
+  when: ansible_os_family == 'Darwin'
+
+- name: set jdk_version
+  set_fact:
+    jdk_version: "1.{{ java_version }}.0_{{ java_subversion }}"
+
+
+#
+# version-specific variables
+#
+
+- name: set internal vars for 1.8.0_131
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b11"
+    jdk_tarball_hash: d54c1d3a095b4ff2b6607d096fa80163
+  when: java_version == 8 and java_subversion == 131
+
+- name: set internal vars for 1.8.0_112
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b15"
+  when: java_version == 8 and java_subversion == 112
+
+- name: set internal vars for 1.8.0_111
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b14"
+  when: java_version == 8 and java_subversion == 111
+
+- name: set internal vars for 1.8.0_102
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b14"
+  when: java_version == 8 and java_subversion == 102
+
+- name: set internal vars for 1.8.0_101
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b13"
+  when: java_version == 8 and java_subversion == 101
+
+- name: set internal vars for 1.8.0_92 or 1.8.0_91
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b14"
+  when: java_version == 8 and (java_subversion == 92 or java_subversion == 91)
+
+- name: set internal vars for 1.8.0_77
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b03"
+  when: java_version == 8 and java_subversion == 77
+
+- name: set internal vars for 1.8.0_74
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b02"
+  when: java_version == 8 and java_subversion == 74
+
+- name: set internal vars for 1.8.0_73
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b02"
+  when: java_version == 8 and java_subversion == 73
+
+- name: set internal vars for 1.8.0_72
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b15"
+  when: java_version == 8 and java_subversion == 72
+
+- name: set internal vars for 1.8.0_66
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b17"
+  when: java_version == 8 and java_subversion == 66
+
+- name: set internal vars for 1.8.0_65
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b17"
+  when: java_version == 8 and java_subversion == 65
+
+- name: set internal vars for 1.8.0_60
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b27"
+  when: java_version == 8 and java_subversion == 60
+
+- name: set internal vars for 1.8.0_51
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b16"
+  when: java_version == 8 and java_subversion == 51
+
+- name: set internal vars for 1.8.0_45
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b14"
+  when: java_version == 8 and java_subversion == 45
+
+- name: set internal vars for 1.8.0_31
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b13"
+  when: java_version == 8 and java_subversion == 31
+
+- name: set internal vars for 1.7.0_80
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b15"
+  when: java_version == 7 and java_subversion == 80
+
+- name: set internal vars for 1.7.0_75
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b13"
+  when: java_version == 7 and java_subversion == 75
+
+- name: set internal vars for generic Java version
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b{{ java_build }}"
+  when: jdk_version_detail is not defined and java_build is defined
+
+
+- name: compose filename
+  set_fact:
+    jdk_tarball_file: "jdk-{{ java_version }}u{{ java_subversion }}-{{ jdk_os }}-{{ jdk_arch }}"
+
+
+#
+# JCE variables
+#
+
+- name: set JCE variables for java 7
+  set_fact:
+    jce_zip_file:   "UnlimitedJCEPolicyJDK{{ java_version }}.zip"
+    jce_zip_folder: "UnlimitedJCEPolicy"
+  when: java_version == 7
+
+- name: set JCE variables for java 8
+  set_fact:
+    jce_zip_file:   "jce_policy-{{ java_version }}.zip"
+    jce_zip_folder: "UnlimitedJCEPolicyJDK{{ java_version }}"
+  when: java_version == 8
+
+- name: set JCE download file, if necessary
+  set_fact:
+    jce_zip_url: "http://download.oracle.com/otn-pub/java/jce/{{ java_version }}/{{ jce_zip_file }}"
+  when: java_install_jce is true
+
+
+#
+# directories
+#
+
+- name: set java installation directory on Mac OS X
+  set_fact:
+    # The Java installation directory on Mac OS X is determined by the package itself.
+    java_install_dir: /no_such_directory
+    java_default_link_name: default
+    java_home: "/Library/Java/JavaVirtualMachines/jdk1.{{ java_version }}.0_{{ java_subversion }}.jdk/Contents/Home"
+  when: ansible_os_family == "Darwin"

--- a/tasks/set-role-variables.yml
+++ b/tasks/set-role-variables.yml
@@ -3,12 +3,6 @@
 # set necessary role variables.
 #
 
-
-- name: set general internal vars
-  set_fact:
-    jdk_version: "1.{{ java_version }}.0_{{ java_subversion }}"
-
-
 #
 # platform-specific variables
 #
@@ -31,138 +25,29 @@
 #
 # version-specific variables
 #
-- name: set internal vars for 1.8.0_131
-  set_fact:
-    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b11"
-    jdk_tarball_hash: d54c1d3a095b4ff2b6607d096fa80163
-  when: java_version == 8 and java_subversion == 131
 
-- name: set internal vars for 1.8.0_112
+- name: check if java_version is semver
   set_fact:
-    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b15"
-  when: java_version == 8 and java_subversion == 112
+    java_version_is_semver: "{{ java_version is regex(\"\\d+\\.\\d+\\.\\d+\") | bool }}"
 
-- name: set internal vars for 1.8.0_111
-  set_fact:
-    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b14"
-  when: java_version == 8 and java_subversion == 111
+- name: include semver variables
+  include_tasks: set-role-variables-semver.yml
+  when: java_version_is_semver is true
 
-- name: set internal vars for 1.8.0_102
-  set_fact:
-    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b14"
-  when: java_version == 8 and java_subversion == 102
+- name: include version / subversion variables
+  include_tasks: set-role-variables-version-subversion.yml
+  when: java_version_is_semver is false
 
-- name: set internal vars for 1.8.0_101
-  set_fact:
-    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b13"
-  when: java_version == 8 and java_subversion == 101
-
-- name: set internal vars for 1.8.0_92 or 1.8.0_91
-  set_fact:
-    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b14"
-  when: java_version == 8 and (java_subversion == 92 or java_subversion == 91)
-
-- name: set internal vars for 1.8.0_77
-  set_fact:
-    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b03"
-  when: java_version == 8 and java_subversion == 77
-
-- name: set internal vars for 1.8.0_74
-  set_fact:
-    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b02"
-  when: java_version == 8 and java_subversion == 74
-
-- name: set internal vars for 1.8.0_73
-  set_fact:
-    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b02"
-  when: java_version == 8 and java_subversion == 73
-
-- name: set internal vars for 1.8.0_72
-  set_fact:
-    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b15"
-  when: java_version == 8 and java_subversion == 72
-
-- name: set internal vars for 1.8.0_66
-  set_fact:
-    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b17"
-  when: java_version == 8 and java_subversion == 66
-
-- name: set internal vars for 1.8.0_65
-  set_fact:
-    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b17"
-  when: java_version == 8 and java_subversion == 65
-
-- name: set internal vars for 1.8.0_60
-  set_fact:
-    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b27"
-  when: java_version == 8 and java_subversion == 60
-
-- name: set internal vars for 1.8.0_51
-  set_fact:
-    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b16"
-  when: java_version == 8 and java_subversion == 51
-
-- name: set internal vars for 1.8.0_45
-  set_fact:
-    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b14"
-  when: java_version == 8 and java_subversion == 45
-
-- name: set internal vars for 1.8.0_31
-  set_fact:
-    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b13"
-  when: java_version == 8 and java_subversion == 31
-
-- name: set internal vars for 1.7.0_80
-  set_fact:
-    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b15"
-  when: java_version == 7 and java_subversion == 80
-
-- name: set internal vars for 1.7.0_75
-  set_fact:
-    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b13"
-  when: java_version == 7 and java_subversion == 75
-
-- name: set internal vars for generic Java version
-  set_fact:
-    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b{{ java_build }}"
-  when: jdk_version_detail is not defined and java_build is defined
-
-
-- name: compose filename, if necessary
-  set_fact:
-    jdk_tarball_file: "jdk-{{ java_version }}u{{ java_subversion }}-{{ jdk_os }}-{{ jdk_arch }}"
-  when: jdk_tarball_file is not defined
 
 - name: compose url for downloading file, if necessary
   set_fact:
     jdk_tarball_url:  "http://download.oracle.com/otn-pub/java/jdk/{{ jdk_version_detail }}/{{ jdk_tarball_file }}"
   when: jdk_version_detail is defined and jdk_tarball_hash is not defined
 
-
 - name: compose url for downloading file, if necessary
   set_fact:
     jdk_tarball_url: "http://download.oracle.com/otn-pub/java/jdk/{{ jdk_version_detail }}/{{ jdk_tarball_hash }}/{{ jdk_tarball_file }}"
   when: jdk_version_detail is defined and jdk_tarball_hash is defined
-
-#
-# JCE variables
-#
-
-- name: set JCE variables for java 7
-  set_fact:
-    jce_zip_file:   "UnlimitedJCEPolicyJDK{{ java_version }}.zip"
-    jce_zip_folder: "UnlimitedJCEPolicy"
-  when: java_version == 7
-
-- name: set JCE variables for java 8
-  set_fact:
-    jce_zip_file:   "jce_policy-{{ java_version }}.zip"
-    jce_zip_folder: "UnlimitedJCEPolicyJDK{{ java_version }}"
-  when: java_version == 8
-
-- name: set JCE download file
-  set_fact:
-    jce_zip_url: "http://download.oracle.com/otn-pub/java/jce/{{ java_version }}/{{ jce_zip_file }}"
 
 
 #
@@ -175,14 +60,6 @@
     java_default_link_name: default-java
     java_home: /usr/lib/jvm/default-java
   when: ansible_os_family == "Debian"
-
-- name: set java installation directory on Mac OS X
-  set_fact:
-    # The Java installation directory on Mac OS X is determined by the package itself.
-    java_install_dir: /no_such_directory
-    java_default_link_name: default
-    java_home: "/Library/Java/JavaVirtualMachines/jdk1.{{ java_version }}.0_{{ java_subversion }}.jdk/Contents/Home"
-  when: ansible_os_family == "Darwin"
 
 - name: set java installation directory on non-Debian platforms
   set_fact:

--- a/tasks/use-dmg.yml
+++ b/tasks/use-dmg.yml
@@ -8,13 +8,23 @@
 - name: mount the downloaded dmg
   shell: hdiutil attach "{{ java_download_path }}/{{ jdk_tarball_file }}.dmg"
 
+- name: set dmg name (semver)
+  set_fact:
+    dmg_name: "JDK {{ java_version }}"
+  when: java_version_is_semver is true
+
+- name: set dmg name (version / subversion)
+  set_fact:
+    dmg_name: "JDK {{ java_version }} Update {{ java_subversion }}"
+  when: java_version_is_semver is false
+
 - name: install the pkg file from the dmg
   become: yes
   become_method: sudo
   shell: >
     installer
-    -pkg "/Volumes/JDK {{ java_version }} Update {{ java_subversion }}/JDK {{ java_version }} Update {{ java_subversion }}.pkg"
+    -pkg "/Volumes/{{ dmg_name }}/{{ dmg_name }}.pkg"
     -target /
 
 - name: unmount the downloaded dmg
-  shell: hdiutil detach "/Volumes/JDK {{ java_version }} Update {{ java_subversion }}"
+  shell: hdiutil detach "/Volumes/{{ dmg_name }}"


### PR DESCRIPTION
Add support for semver `java_version`s starting with 11.0.10.

Example play:
```yaml
---
- hosts: all
  tasks:
    - name: "Install JDK 11.0.10"
      include_role:
        name: ansible-role-java
      vars:
        java_version: "11.0.10"
    - name: "Install JDK 8u131"
      include_role:
        name: ansible-role-java
      vars:
        java_version: 8
        java_subversion: 131
```

TODO:
 - [x] fix checking if already installed